### PR TITLE
Fix bug parsing dependencies from feature.xml

### DIFF
--- a/compilation/gradle.dependency/src/main/groovy/de/monkeyworks/buildmonkey/dependency/ManifestDependencyPlugin.groovy
+++ b/compilation/gradle.dependency/src/main/groovy/de/monkeyworks/buildmonkey/dependency/ManifestDependencyPlugin.groovy
@@ -178,7 +178,7 @@ class ManifestDependencyPlugin implements Plugin<Project> {
         def evaluationStrategy = {
             def parsedXML = new XmlSlurper().parse(it)
             def extractFromXML = { String nodeName, String attribute ->
-                return parsedXML.'**'.findAll { node -> node.name() == nodeName }.collect { it["@$attribute"] }
+                return parsedXML.'**'.findAll { node -> node.name() == nodeName }.collect { it["@$attribute"].text() }
             }
             return extractFromXML("plugin", "id") + extractFromXML("import", "plugin") + extractFromXML("include", "id")
         }


### PR DESCRIPTION
Return a list of string representations of XML attributes instead of the
attributes itself (which caused a type mismatch) from parsing method.

The bug caused following error when importing features via Buildship in Eclipse:

> A problem occurred configuring project ':my_feature'.
No signature of method: de.monkeyworks.buildmonkey.dependency.ManifestDependencyPlugin$_addTasksForResolveDependencies_closure1$_closure8$_closure12.doCall() is applicable for argument types: (groovy.util.slurpersupport.Attributes) values: [my.plugin.url]
Possible solutions: doCall(java.lang.String), findAll(), findAll(), isCase(java.lang.Object), isCase(java.lang.Object)
...
Caused by: groovy.lang.MissingMethodException: No signature of method: de.monkeyworks.buildmonkey.dependency.ManifestDependencyPlugin$_addTasksForResolveDependencies_closure1$_closure8$_closure12.doCall() is applicable for argument types: (groovy.util.slurpersupport.Attributes) values: [my.plugin.url]
Possible solutions: doCall(java.lang.String), findAll(), findAll(), isCase(java.lang.Object), isCase(java.lang.Object)
	at de.monkeyworks.buildmonkey.dependency.ManifestDependencyPlugin$_addTasksForResolveDependencies_closure1$_closure8.doCall(ManifestDependencyPlugin.groovy:106)
